### PR TITLE
Update workflows for manual trigger and yarn usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
-on: [push]
+on:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,12 +12,22 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - run: npm i && npm i yarn
-      - run: npm publish
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build
+
+#      - run: npm i && npm i yarn
+      - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
 build
+
+.idea/
+.vscode/
+.fleet/


### PR DESCRIPTION
Enable workflow_dispatch for manual runs in the build workflow. Switch from npm to yarn in the npm-publish workflow and add build step before publishing.